### PR TITLE
V3/updates

### DIFF
--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -524,7 +524,7 @@ function Add-Settings {
             if (Test-Path "$env:PowerShellHome\Images\$settingName.jpg"){
                 $date = Get-Date -format 'MM-dd-yyyy_hhmmss'
                 Copy-Item -Path "$env:PowerShellHome\Images\$settingName.jpg" `
-                -Destination "$env:PowerShellHome\Images\$date.jpg"
+                -Destination "$env:PowerShellHome\Images\$date-$settingName.jpg"
             }
 
             Copy-Item -Path $backgroundImage `

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -725,8 +725,11 @@ function Set-OhMyPrompt([string]$settingsFilePath, [switch]$chp){
     if (!$chp){
         <#get filenames for themes#>
         $themes = Get-Item -Path "$env:PowershellPrompts/*" -Include *.json
-        $names = $themes | Get-ItemPropertyValue -Name BaseName
-        Write-Output $names "`n"
+        $themeNames = $themes | Get-ItemPropertyValue -Name BaseName
+        #Write-Output $names "`n"
+        for ($count = 0; $count -lt  $themeNames.Count; $count++){
+            Write-Host $($count+1) $themeNames[$count] "`n"
+        }
         $selection = Read-Host "Please select an option (1-$($themes.Count))"
         # parse number
         switch ([int]$selection) {

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -54,7 +54,9 @@ function New-Settings {
     .$PSScriptRoot/Set-Defaults
     $PSSettings = Get-Content -Raw "$env:USERPROFILE\AppData\Local\Packages\Microsoft.WindowsTerminal_$env:PackagePublisherId\LocalState\settings.json" | ConvertFrom-Json
     <#mod settings to all values#>
-    Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name defaultProfile -Value "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" -Force
+    # default terminal host: powershell or windows powershell
+    Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name defaultProfile -Value "{574e775e-4f2a-5b96-ac1e-a2962a402336}" -Force
+    # Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name defaultProfile -Value "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" -Force
     Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name initialCols -Value $PRDefaultParameterValues."Add-Settings:initCols" -Force
     Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name initialRows -Value $PRDefaultParameterValues."Add-Settings:initRows" -Force
     Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name newTabPosition -Value $PRDefaultParameterValues."Add-Settings:newTabPlacement" -Force

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -14,7 +14,6 @@ function Set-Environment {
         [string] $PowerShellProfilePath
     )
 
-    
     if(!($PSBoundParameters.ContainsKey('PowerShellProfilePath'))){
         $host.UI.RawUI.ForegroundColor = 'Green'
         $PowerShellProfilePath = Read-Host "Supply the path to your profile.ps1 file"
@@ -692,16 +691,20 @@ function Switch-Profile {
         [string] $settingName = 'defaults'
     )
 
+    
     if($settingName -eq 'defaults'){
         .$PSSCriptRoot/Set-Defaults
         return pps defaults -r -nc
     }
+    
     Copy-Item -Path "$env:PowerShellHome\Settings\$settingName.json" `
-     -Destination "$env:USERPROFILE\AppData\Local\Packages\Microsoft.WindowsTerminal_$env:PackagePublisherId\LocalState\settings.json" `
-     -ErrorAction SilentlyContinue -ErrorVariable noCopy
+    -Destination "$env:USERPROFILE\AppData\Local\Packages\Microsoft.WindowsTerminal_$env:PackagePublisherId\LocalState\settings.json" `
+    -ErrorAction SilentlyContinue -ErrorVariable noCopy
     if($noCopy){
         Write-Host `n "No saved profile settings for this option found." `n -ForegroundColor Magenta
+        return
     }
+    Set-OhMyPrompt "$env:PowerShellHome\Settings\$settingName.json" -chp
 } 
 
 function Set-OhMyPrompt([string]$settingsFilePath, [switch]$chp){
@@ -717,7 +720,9 @@ function Set-OhMyPrompt([string]$settingsFilePath, [switch]$chp){
         $names = $themes | Get-ItemPropertyValue -Name BaseName
         Write-Output $names "`n"
         $selection = Read-Host "Please select an option (1-$($themes.Count))"
-        switch ($selection) {
+        # parse number
+        Write-Host $themes[$selection]
+        switch ([int]$selection) {
             { $_ -ge 1 -and $_ -le $themes.Count } {
                 $index = [int]$selection - 1
                 $selectedOption = $themes[$index]
@@ -742,6 +747,7 @@ function Set-OhMyPrompt([string]$settingsFilePath, [switch]$chp){
         if ($null -ne $PSSettings.promptSetting){
             $myProfile = @(Get-Content -Path $PowerShellProfile)
             $myProfile[0] = $PSSettings.promptSetting
+            $myProfile | Set-Content -Path $PowerShellProfile -Force
             . $env:PowerShellHome/profile.ps1
         }
     }

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -7,7 +7,9 @@ This command sets up your environment variables to work with PosEr.
 function Set-Environment {
     param (
         <#String path to the DIRECTORY containing your PowerShell profile.ps1#>
-        <#default is $env:USERPROFILE\Documents\WindowsPowerShell#>
+        <#For PowerShell only, $env:USERPROFILE\Documents\PowerShell#>
+        <#For WindowsPowerShell only, use $env:USERPROFILE\Documents\WindowsPowerShell#>
+        <#Or, add your own custom profile directory here!#>
         [Parameter(
             Mandatory = $true
         )]
@@ -15,7 +17,7 @@ function Set-Environment {
     )
 
     if(!$PSBoundParameters.ContainsKey('PowerShellProfilePath')){
-        $PowerShellProfilePath = '$env:USERPROFILE\Documents\WindowsPowerShell'
+        $PowerShellProfilePath = '$env:USERPROFILE\Documents\PowerShell'
     }
     $pkgId = Get-AppPackage Microsoft.WindowsTerminal | Select-Object -ExpandProperty PublisherId
 
@@ -505,10 +507,10 @@ function Add-Settings {
             -Destination $PRDefaultParameterValues."Add-Settings:backgroundImage"
         }
             <#settings#>
-        if($initCols -ne $SettingsObject.initialCols -and $PSBoundParameters.ContainsKey('initialCols')){
+        if($initCols -ne $SettingsObject.initialCols -and $PSBoundParameters.ContainsKey('initCols')){
             $SettingsObject.initialCols = $initialCols
         }
-        if($initRows -ne $SettingsObject.initialRows -and $PSBoundParameters.ContainsKey('initialRows')){
+        if($initRows -ne $SettingsObject.initialRows -and $PSBoundParameters.ContainsKey('initRows')){
             $SettingsObject.initialRows = $initialRows
         }
         if($newTabPlacement -ne $SettingsObject.newTabPosition -and $PSBoundParameters.ContainsKey('newTabPlacement')){

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -39,7 +39,8 @@ function Set-Environment {
     mkdir -p $PowerShellProfilePath'\Prompts'
     mkdir -p $PowerShellProfilePath'\Images'
     mkdir -p $PowerShellProfilePath'\Settings'
-<#may have an issue with this when running manually#>
+
+    Copy-Item -Path "$PSScriptRoot\settings.psd1" -Destination "$PowerShellProfilePath\Settings\settings.psd1"
     Copy-Item -Path "$PSScriptRoot\img\background.jpg" -Destination "$PowerShellProfilePath\Images\background.jpg"
     <#oh-my-posh themes#>
     Copy-Item -Path "$env:POSH_THEMES_PATH\*"  -Destination "$PowerShellProfilePath\Prompts" -ErrorAction SilentlyContinue -ErrorVariable $noPrompts
@@ -622,7 +623,7 @@ function Add-Settings {
         }
         if ($continue -ieq "y"){
             $outputFile = $PSSettings
-            $defaultParams = Get-Content -Path $PSScriptRoot\settings.psd1 
+            $defaultParams = Get-Content -Path "$env:PowerShellHome\Settings\settings.psd1" 
             if($PSBoundParameters.ContainsKey('initCols')){$defaultParams[1] = "`t'Add-Settings:initCols'='$initCols'"}
             if($PSBoundParameters.ContainsKey('initRows')){$defaultParams[2] = "`t'Add-Settings:initRows'='$initRows'"}
             if($PSBoundParameters.ContainsKey('newTabPlacement')){$defaultParams[3] = "`t'Add-Settings:newTabPlacement'='$newTabPlacement'"}
@@ -653,7 +654,7 @@ function Add-Settings {
             if($PSBoundParameters.ContainsKey('inputSnap')){$defaultParams[28] = "`t'Add-Settings:inputSnap'='$inputSnap'"}
             if($PSBoundParameters.ContainsKey('acrylicBg')){$defaultParams[29] = "`t'Add-Settings:acrylicBg'='$acrylicBg'"}
             if($PSBoundParameters.ContainsKey('atlasEngine')){$defaultParams[30] = "`t'Add-Settings:atlasEngine'='$atlasEngine'"}
-            $defaultParams | Set-Content -Path $PSScriptRoot\settings.psd1 -Force
+            $defaultParams | Set-Content -Path "$env:PowerShellHome\Settings\settings.psd1" -Force
         } else {
             return
         }
@@ -662,6 +663,7 @@ function Add-Settings {
     }
 
     <# necessary Depth level 3, this is subject to change if the powershell settings file obtains further nested values #>
+    Write-Host "Updating $settingName settings..." -ForegroundColor Cyan
     $SettingsObject | ConvertTo-Json -Depth 100 | Set-Content $outputFile
     
     if($settingName -ine 'defaults'){

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -41,6 +41,11 @@ function Set-Environment {
     mkdir -p $PowerShellProfilePath'\Settings'
 <#may have an issue with this when running manually#>
     Copy-Item -Path "$PSScriptRoot\img\background.jpg" -Destination "$PowerShellProfilePath\Images\background.jpg"
+    <#oh-my-posh themes#>
+    Copy-Item -Path "$env:POSH_THEMES_PATH\*"  -Destination "$PowerShellProfilePath\Prompts" -ErrorAction SilentlyContinue -ErrorVariable $noPrompts
+    if ($noPrompts){
+        Write-Host "No themes were found for 'oh-my-posh'" -ForegroundColor Magenta
+    }
 }
 
 function New-Settings {
@@ -56,7 +61,7 @@ function New-Settings {
     Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name theme -Value $PRDefaultParameterValues."Add-Settings:theme" -Force
     Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name useAcrylicInTabRow -Value $PRDefaultParameterValues."Add-Settings:useAcrylicTab" -Force
     Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name windowingBehavior -Value $PRDefaultParameterValues."Add-Settings:newTabAttach" -Force
-    Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name promptSetting -Value ""
+    Add-Member -InputObject $PSSettings -MemberType NoteProperty -Name promptSetting -Value "oh-my-posh init pwsh --config $env:PowerShellPrompts\atomic.omp.json | Invoke-Expression" -Force
     $PSSettings.themes[$PSSettings.themes.Count-1] = [PSCustomObject]@{
         <#we may put name key here,just to make sure it is custom, or if it doesn't work without it#>
             name = $PRDefaultParameterValues."Add-Settings:theme"
@@ -407,6 +412,7 @@ function Add-Settings {
         $atlasEngine,
 
     <#Oh-My-Posh theme setting#>
+    <#Only used for local or presentation settings#>
     <#Switches do not take arguments#>
         [Parameter()]
         [switch] $omp,
@@ -721,7 +727,6 @@ function Set-OhMyPrompt([string]$settingsFilePath, [switch]$chp){
         Write-Output $names "`n"
         $selection = Read-Host "Please select an option (1-$($themes.Count))"
         # parse number
-        Write-Host $themes[$selection]
         switch ([int]$selection) {
             { $_ -ge 1 -and $_ -le $themes.Count } {
                 $index = [int]$selection - 1

--- a/3.0.0/PosEr.psm1
+++ b/3.0.0/PosEr.psm1
@@ -520,13 +520,18 @@ function Add-Settings {
         <#update the settings object#>
         .$PSScriptRoot/Set-Defaults
         if($backgroundImage -ne $settingsObject.profiles.defaults.backgroundImage -and $PSBoundParameters.ContainsKey('backgroundImage')){
-            $SettingsObject.profiles.defaults.backgroundImage = $backgroundImage
-            <#copy both and put new img in folder#>
-            $date = Get-Date -format 'MM-dd-yyyy_hhmmss'
-            Copy-Item -Path $PRDefaultParameterValues."Add-Settings:backgroundImage" `
-            -Destination "$env:PowerShellHome\Images\$date.jpg"
+            <#copy old image, save to archive, copy new bg to setting#>
+            if (Test-Path "$env:PowerShellHome\Images\$settingName.jpg"){
+                $date = Get-Date -format 'MM-dd-yyyy_hhmmss'
+                Copy-Item -Path "$env:PowerShellHome\Images\$settingName.jpg" `
+                -Destination "$env:PowerShellHome\Images\$date.jpg"
+            }
+
             Copy-Item -Path $backgroundImage `
-            -Destination $PRDefaultParameterValues."Add-Settings:backgroundImage"
+            -Destination "$env:PowerShellHome\Images\$settingName.jpg"
+
+            $SettingsObject.profiles.defaults.backgroundImage = "$env:PowerShellHome\Images\$settingName.jpg"
+
         }
             <#settings#>
         if($initCols -ne $SettingsObject.initialCols -and $PSBoundParameters.ContainsKey('initCols')){

--- a/3.0.0/Set-Defaults.ps1
+++ b/3.0.0/Set-Defaults.ps1
@@ -1,4 +1,7 @@
 $defaultsHashTable = Import-PowerShellDataFile -Path "$PSScriptRoot\settings.psd1"
+if(Test-Path "$env:PowerShellHome\Settings\settings.psd1"){
+    $defaultsHashTable = Import-PowerShellDataFile -Path "$env:PowerShellHome\Settings\settings.psd1"
+}
 $PRDefaultParameterValues = $defaultsHashTable
 <#cannot import objects with dynamic variables, should set this the Add-Settings script#>
 $PRDefaultParameterValues.Add("Add-Settings:backgroundImage", "$PSScriptRoot\img\background.jpg")

--- a/3.0.0/settings.psd1
+++ b/3.0.0/settings.psd1
@@ -1,6 +1,6 @@
 @{
-	'Add-Settings:initCols'=90
-	'Add-Settings:initRows'=30
+	'Add-Settings:initCols'=70
+	'Add-Settings:initRows'=20
 	'Add-Settings:newTabPlacement'='afterLastTab'
 	'Add-Settings:tabWidthMode'='titleLength'
 	'Add-Settings:theme'='custom'

--- a/readme.md
+++ b/readme.md
@@ -5,21 +5,25 @@
 
 ### *Set Up the Module*
 
-<mark>&nbsp;*You must have [__windows terminal__](https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701) to use this module.&nbsp;</mark>
+<mark>&nbsp;*You must have [__windows terminal__](https://github.com/microsoft/terminal) to use this module.&nbsp;</mark>
 
 1. Once you have terminal installed, open a new instance of '__Windows Powershell__', or use the keyboard shortcut '__Ctrl + Shift + 1__'.
 
 2. Copy the module into your modules directory. You can find the directories availiable using the command:
 
-```pwsh
-$env:PSModulePath
-```
+   ```pwsh
+   $env:PSModulePath
+   ```
 
-1. Then use the following command to import the module,
+   It is recommended you put the module in "__C:\Program Files\WindowsPowerShell\Modules__" in order to use it with all powershell hosts.
 
-```pwsh
-Import-Module PosEr
-```
+3. Then use the following command to import the module,
+
+   ```pwsh
+   Import-Module PosEr
+   ```
+
+   <font color="green">*It is recommended to add this line to your '__profile.ps1__'</font>
 
 The module contains four functions for your use:
 
@@ -28,7 +32,8 @@ The module contains four functions for your use:
 * Add-Settings
 * Switch-Profile
 
-Use the __`'Set-Environment'`__ command and supply the '__PowerShellProfilePath__' parameter with the folder you have your PowerShell profile script in. If the profile script is pointing to another, do not use the path to it, use the path to the '__profile.ps1__' you're pointing at.  
+Use the __`'Set-Environment'`__ command and supply the '__PowerShellProfilePath__' parameter with the path to the folder you have your PowerShell profile script in. If the profile script is pointing to another, do not use the path to it; instead, use the path to the '__profile.ps1__' you're pointing at.  
+
 The module will then create environment variables and folders to use.  
 Use the __`'New-Settings'`__ command to run the initial setup for the terminal settings. If this is not done, it will automatically run when attempting to use the module the first time.  
 &nbsp;
@@ -54,7 +59,7 @@ Add-Settings defaults [-option] [value]
 <mark>Hint:</mark>
 <font color=Magenta>Using the __Add-Settings__ or __Switch-Profile__ commands without a setting name will default to 'defaults'.</font>  
 
-The options are:
+The options are (see the [help](#help) for more detailed information):
 
 * <font color="cyan">initCols</font>
 * <font color="cyan">initRows</font>
@@ -89,9 +94,7 @@ The options are:
 * <font color="cyan">acrylicBg</font>
 * <font color="cyan">atlasEngine</font>
 
-To save settings, there are two profiles available that can be created with the __`'Add-Settings'`__ command- `'local'` and `'presentation'`. Supply values for as many parameters as you desire per call.
-
-<font color=magenta>__*Don't supply values for options you wish to use their defaults for.__</font>  
+To save settings, there are two profiles available that can be created with the __`'Add-Settings'`__ command- `'local'` and `'presentation'`. Supply values for as many parameters as you desire per call.  
 &nbsp;
 
 ### *Run the Switch-Profile Command*
@@ -132,24 +135,23 @@ pps presentation -cs 'Vintage'
 * <font color="orange">omp</font>
 
 *Use __`'pps -r'`__ with the '__local__' or '__presentation__' setting to reset the values to defaults.  
-*Use __`'pps -nc'`__ with the '__defaults__' setting to skip confirmation of changing the module's default values.
-*Use __`'pps -omp'`__ to set the oh-my-posh prompt theme.
+*Use __`'pps -nc'`__ with the '__defaults__' setting to skip confirmation of changing the module's default values.  
+*Use __`'pps <setting name> -omp'`__ to set the oh-my-posh prompt theme.  
+<font color="magenta">The -omp switch only affects the '__local__' and '__presentation__' settings.</font>
 
 #### Setting the prompt theme
 
-In your profile.ps1 you should have the following line for loading your '__oh-my-posh__' theme:  
+In your '__profile.ps1__' you should have the following as the first line, for loading your '__oh-my-posh__' theme:  
 `oh-my-posh init pwsh --config $env:PowerShellPrompts\<theme name>.json | Invoke-Expression`  
 
-<font color="red">*__This line needs to be the first line in your profile.ps1 file in order to work properly with this module.__</font>
-
-Use the __`'-omp'`__ switch to change themes.  
+<font color="red">*__This must be the first line in your profile.ps1 file in order to work properly with this module.__</font>  
 &nbsp;  
 
 ### *Help*
 
 In order to view the help documentation:
 
-1. Explicitly import the '__Poser__' module
+1. If the import statement is not in your '__profile.ps1__', explicitly import the '__Poser__' module
 
    ```pwsh
    Import-Module Poser

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ The module contains four functions for your use:
 * Add-Settings
 * Switch-Profile
 
-Use the __`'Set-Environment'`__ command and supply the '__PowerShellProfilePath__' parameter with the folder you have your PowerShell profile script in.  
+Use the __`'Set-Environment'`__ command and supply the '__PowerShellProfilePath__' parameter with the folder you have your PowerShell profile script in. If the profile script is pointing to another, do not use the path to it, use the path to the '__profile.ps1__' you're pointing at.  
 The module will then create environment variables and folders to use.  
 Use the __`'New-Settings'`__ command to run the initial setup for the terminal settings. If this is not done, it will automatically run when attempting to use the module the first time.  
 &nbsp;


### PR DESCRIPTION
# Featured Changes

* created default settings writable so module doesn't need elevated shell to work when installed in common folder
    * can't write to `Program Files` without modifying permissions
* added help notes on profile location
* some settings did not work, such as launch size for terminal
* module sets variables on first use so shell does not need to exit to be used after running `Set-Environment`
* added prompt setting to settings file
    * `Set-OhMyPrompt` function now sets the prompt when changing profile and writes the setting data when changing settings.
* fixed background images to load for both profiles